### PR TITLE
added skip on cran

### DIFF
--- a/tests/testthat/test-demo-crowding.R
+++ b/tests/testthat/test-demo-crowding.R
@@ -4,6 +4,7 @@
 #' 
 #tests class and typeof output
 test_that("Output data type is correct", {
+  skip_on_cran()
   output <- demo_crowding(area = "wa",
                           areatype = "hsa", 
                           crowding = "household with >1 person per room",
@@ -14,6 +15,7 @@ test_that("Output data type is correct", {
 
 #Ensures that variables are present and working on SCP
 test_that("demo-crowding returns non-empty data frame", {
+  skip_on_cran()
   crowding1 <- demo_crowding(area = "wa",
                              areatype = "hsa", 
                              crowding = "household with >1 person per room",
@@ -23,6 +25,7 @@ test_that("demo-crowding returns non-empty data frame", {
 
 #demo-crowding must have 5 columns
 test_that("demo-crowding has correct number of columns", {
+  skip_on_cran()
   df <- demo_crowding(area = "wa",
                       areatype = "hsa", 
                       crowding = "household with >1 person per room",

--- a/tests/testthat/test-demo-education.R
+++ b/tests/testthat/test-demo-education.R
@@ -4,6 +4,7 @@
 #' 
 #tests class and typeof output
 test_that("Output data type is correct", {
+  skip_on_cran()
   output <- demo_education("wa", "county", "at least high school", "males")
   
   expect_true(inherits(output, "data.frame"))
@@ -11,6 +12,7 @@ test_that("Output data type is correct", {
 
 #Ensures that variables are present and working on SCP
 test_that("demo-education returns non-empty data frame", {
+  skip_on_cran()
   education1 <- demo_education("wa", "county", "at least high school", "males")
   expect_true(is.data.frame(education1))
   
@@ -24,6 +26,7 @@ test_that("demo-education returns non-empty data frame", {
 
 #demo-education must have 5 columns
 test_that("demo-education has correct number of columns", {
+  skip_on_cran()
   df <- demo_education("wa", "county", "at least high school", "both sexes")
   expected_columns <- 5
   expect_equal(ncol(df), expected_columns)
@@ -33,6 +36,7 @@ test_that("demo-education has correct number of columns", {
 
 #write one for error handling in education - mention in the message how values could have chnaged in SCP
 test_that("demo-education handles invalid education parameters", {
+  skip_on_cran()
   expect_error(
     demo_education("wa", "county", "less than 9th grade", "males"),
     "For Less than 9th Grade, Race and Sex must be NULL"

--- a/tests/testthat/test-demo-food-access.R
+++ b/tests/testthat/test-demo-food-access.R
@@ -4,6 +4,7 @@
 
 #tests class and typeof output
 test_that("Output data type is correct", {
+  skip_on_cran()
   output <- demo_food("wa", "county", "food insecurity", "black")
   
   expect_equal(class(output), "data.frame",
@@ -15,6 +16,7 @@ test_that("Output data type is correct", {
 
 #Ensures that variables are present and working on SCP
 test_that("demo-food returns non-empty data frame", {
+  skip_on_cran()
   food_test_1 <- demo_food("wa", "county", "food insecurity", "all races (includes hispanic)")
   expect_true(!is.null(food_test_1))
   expect_true(is.data.frame(food_test_1))
@@ -31,6 +33,7 @@ test_that("demo-food returns non-empty data frame", {
 # sometimes functions will output different nuber of columns depending on variables...
 # demo-food must have 5 columns
 test_that("demo-food has correct number of columns", {
+  skip_on_cran()
   df <- demo_food("wa", "county", "food insecurity", "black")
   df2 <- demo_food("wa", "county", "limited access to healthy food")
   expected_columns <- 3
@@ -41,6 +44,7 @@ test_that("demo-food has correct number of columns", {
 
 #test error handling
 test_that("demo-food handles invalid education parameters", {
+  skip_on_cran()
   expect_error(
     demo_food("wa", "county", "limited access to healthy food", "all races (includes hispanic)"),
     "For limited access to healthy food, Race must be NULL"
@@ -54,24 +58,4 @@ test_that("demo-food handles invalid education parameters", {
 #parameter
 test_that("demo-food has correct parameters", {
   expect_error(demo_food())
-  expect_error(demo_food("wa", "county", "all races (includes hispanic)", "food insecurity"))
 })
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/tests/testthat/test-demo-income.R
+++ b/tests/testthat/test-demo-income.R
@@ -4,6 +4,7 @@
 #' 
 #tests class and typeof output
 test_that("Output data type is correct", {
+  skip_on_cran()
   output <- demo_income("wa", "county", "median family income", "all races (includes hispanic)")
   
   expect_true(inherits(output, "data.frame"))
@@ -11,6 +12,7 @@ test_that("Output data type is correct", {
 
 #Ensures that variables are present and working on SCP
 test_that("demo-income returns non-empty data frame", {
+  skip_on_cran()
   income1 <- demo_income("wa", "county", "median family income", "all races (includes hispanic)")
   expect_true(is.data.frame(income1))
   
@@ -20,6 +22,7 @@ test_that("demo-income returns non-empty data frame", {
 
 #demo-income must have 5 columns
 test_that("demo-income has correct number of columns", {
+  skip_on_cran()
   df <- demo_income("usa", "state", "median household income", "all races (includes hispanic)")
   expected_columns <- 4
   expect_equal(ncol(df), expected_columns)

--- a/tests/testthat/test-demo-insurance.R
+++ b/tests/testthat/test-demo-insurance.R
@@ -4,6 +4,7 @@
 #' 
 #tests class and typeof output
 test_that("Output data type is correct", {
+  skip_on_cran()
   output <- demo_insurance("usa", "state", "% Insured in demographic group, all income levels", 
                            "both sexes", "under 19 years", "all races (includes hispanic)")
   
@@ -26,6 +27,7 @@ insurance_options <- c("% Insured in demographic group, all income levels",
 
 for (option in insurance_options) {
   test_that("demo-insurance returns non-empty data frame", {
+    skip_on_cran()
     expect_true(is.data.frame(demo_insurance("usa", "state", option, "both sexes", 
                                              "under 19 years", "all races (includes hispanic)")))
   })
@@ -33,6 +35,7 @@ for (option in insurance_options) {
 
 #demo-insurance must have 5 columns
 test_that("demo-insurance has correct number of columns", {
+  skip_on_cran()
   df <- demo_insurance("wa", "hsa", "% Insured in demographic group, all income levels", 
                        "males", "18 to 64 years")
   expected_columns <- 5
@@ -40,9 +43,8 @@ test_that("demo-insurance has correct number of columns", {
 })
 
 #test error handling
-
-#write one for error handling in insurance - mention in the message how values could have chnaged in SCP
 test_that("demo-insurance handles invalid insurance parameters", {
+  skip_on_cran()
   expect_error(
     demo_insurance("wa", "county", "% Insured in demographic group, all income levels", 
                    "males", "18 to 64 years", "all races (includes hispanic)")

--- a/tests/testthat/test-demo-mobility.R
+++ b/tests/testthat/test-demo-mobility.R
@@ -4,12 +4,11 @@
 #' 
 #tests class and typeof output
 test_that("Output data type is correct", {
+  skip_on_cran()
   output <- demo_mobility("wa", "county", "moved, different county, same state (in past year)")
   
   expect_true(inherits(output, "data.frame"))
 })
-
-
 
 mobility_options <- c("i haven't moved (in past year)", 
                       "moved from outside us (in past year)", 
@@ -20,12 +19,14 @@ mobility_options <- c("i haven't moved (in past year)",
 
 for (option in mobility_options) {
   test_that("demo-mobility returns non-empty data frame", {
+    skip_on_cran()
     expect_true(is.data.frame(demo_mobility("wa", "county", option)))
   })
 }
 
 #demo-mobility must have 5 columns
 test_that("demo-mobility has correct number of columns", {
+  skip_on_cran()
   df <- demo_mobility("wa", "county", "moved, different county, same state (in past year)")
   expected_columns <- 5
   expect_equal(ncol(df), expected_columns)

--- a/tests/testthat/test-demo-non-english-language.R
+++ b/tests/testthat/test-demo-non-english-language.R
@@ -4,6 +4,7 @@
 #' 
 #tests class and typeof output
 test_that("Output data type is correct", {
+  skip_on_cran()
   output <- demo_language("wa", "county", "language isolation")
   
   expect_true(inherits(output, "data.frame"))
@@ -11,12 +12,14 @@ test_that("Output data type is correct", {
 
 #Ensures that variables are present and working on SCP
 test_that("demo-language returns non-empty data frame", {
+  skip_on_cran()
   language1 <- demo_language("wa", "county", "language isolation")
   expect_true(is.data.frame(language1))
 })
 
 #demo-language must have 5 columns
 test_that("demo-language has correct number of columns", {
+  skip_on_cran()
   df <- demo_language("wa", "county", "language isolation")
   expected_columns <- 5
   expect_equal(ncol(df), expected_columns)

--- a/tests/testthat/test-demo-population.R
+++ b/tests/testthat/test-demo-population.R
@@ -4,6 +4,7 @@
 #' 
 #tests class and typeof output
 test_that("Output data type is correct", {
+  skip_on_cran()
   output <- demo_population("WA", "county", "asian/pacific islander", sex="females")
   
   expect_true(inherits(output, "data.frame"))
@@ -24,6 +25,7 @@ population_options <- list(
 
 for (option_name in names(population_options)) {
   test_that("demo-population returns non-empty data frame", {
+    skip_on_cran()
     option <- population_options[[option_name]]
     expect_true(is.data.frame(option))
   })
@@ -34,12 +36,14 @@ race_options <- c("american indian/alaska native", "asian/pacific islander",
 
 for (option in race_options) {
   test_that("demo-population returns non-empty data frame", {
+    skip_on_cran()
     expect_true(is.data.frame(demo_population("wa", "county", option, sex="both sexes")))
   })
 }
 
 #demo-population must have 5 columns
 test_that("demo-population has correct number of columns", {
+  skip_on_cran()
   df <- demo_population("WA", "county", "asian/pacific islander", sex="females")
   expected_columns <- 5
   expect_equal(ncol(df), expected_columns)
@@ -47,6 +51,7 @@ test_that("demo-population has correct number of columns", {
 
 #test error handling
 test_that("demo-population handles invalid population parameters", {
+  skip_on_cran()
   expect_error(
     demo_population("wa", "county", "ages 40 and over", race="all races includes hispanic"),
     "ages 40 and over and ages 50 and over, Race and Sex must be NULL"

--- a/tests/testthat/test-demo-poverty.R
+++ b/tests/testthat/test-demo-poverty.R
@@ -4,6 +4,7 @@
 #' 
 #tests class and typeof output
 test_that("Output data type is correct", {
+  skip_on_cran()
   output <- demo_poverty("wa", "county", "persistent poverty")
   
   expect_true(inherits(output, "data.frame"))
@@ -19,6 +20,7 @@ poverty_options <- list(
 
 for (option_name in names(poverty_options)) {
   test_that("demo-poverty returns non-empty data frame", {
+    skip_on_cran()
     option <- poverty_options[[option_name]]
     expect_true(is.data.frame(option))
   })
@@ -26,6 +28,7 @@ for (option_name in names(poverty_options)) {
 
 #demo-poverty must have 5 columns
 test_that("demo-poverty has correct number of columns", {
+  skip_on_cran()
   df1 <- demo_poverty("wa", "county", "persistent poverty")
   df2 <- demo_poverty("wa", "county", "families below poverty", "black")
   expected_columns1 <- 3
@@ -36,6 +39,7 @@ test_that("demo-poverty has correct number of columns", {
 
 #test error handling
 test_that("demo-poverty handles invalid poverty parameters", {
+  skip_on_cran()
   expect_error(
     demo_poverty("wa", "hsa", "persistent poverty"),
     "For persistent poverty, areatype must be county"

--- a/tests/testthat/test-demo-svi.R
+++ b/tests/testthat/test-demo-svi.R
@@ -4,6 +4,7 @@
 #' 
 #tests class and typeof output
 test_that("Output data type is correct", {
+  skip_on_cran()
   output <- demo_svi("wa", "overall")
   
   expect_true(inherits(output, "data.frame"))
@@ -16,12 +17,14 @@ svi_options <- c("Overall", "socioeconomic status", "household characteristics",
 
 for (option in svi_options) {
   test_that("demo-svireturns non-empty data frame", {
+    skip_on_cran()
     expect_true(is.data.frame(demo_svi("wa", option)))
   })
 }
 
 #demo-svi must have 5 columns
 test_that("demo-svi has correct number of columns", {
+  skip_on_cran()
   df <- demo_svi("wa", "overall")
   expected_columns <- 3
   expect_equal(ncol(df), expected_columns)

--- a/tests/testthat/test-demo-workforce.R
+++ b/tests/testthat/test-demo-workforce.R
@@ -4,6 +4,7 @@
 #' 
 #tests class and typeof output
 test_that("Output data type is correct", {
+  skip_on_cran()
   output <- demo_workforce("wa", "county", "unemployed",
                            "all races (includes hispanic)", "both sexes")
   
@@ -12,6 +13,7 @@ test_that("Output data type is correct", {
 
 #Ensures that variables are present and working on SCP
 test_that("demo-workforce returns non-empty data frame", {
+  skip_on_cran()
   workforce1 <- demo_workforce("wa", "county", "unemployed",
                                "all races (includes hispanic)", "both sexes")
   expect_true(is.data.frame(workforce1))
@@ -19,6 +21,7 @@ test_that("demo-workforce returns non-empty data frame", {
 
 #demo-workforce must have 5 columns
 test_that("demo-workforce has correct number of columns", {
+  skip_on_cran()
   df <- demo_workforce("wa", "county", "unemployed",
                        "all races (includes hispanic)", "both sexes")
   expected_columns <- 5

--- a/tests/testthat/test-incidence-cancer.R
+++ b/tests/testthat/test-incidence-cancer.R
@@ -4,6 +4,7 @@
 #'
 # tests class and typeof output
 test_that("Output data type is correct", {
+  skip_on_cran()
   output <- incidence_cancer("wa", "county", "all cancer sites", "black (non-hispanic)", 
                              "both sexes", "ages 65+", "all stages", "latest 5 year average")
   
@@ -18,6 +19,7 @@ cancer_options <- c("all cancer sites","bladder", "brain & ons", "colon & rectum
 
 for (option in cancer_options) {
   test_that("incidence cancer returns non-empty data frame", {
+    skip_on_cran()
     result <- incidence_cancer("wa", "county", option, "all races (includes hispanic)", 
                                "both sexes", "all ages", "all stages", "latest 5 year average")
     expect_true(is.data.frame(result))
@@ -29,6 +31,7 @@ female_cancer_options <- c("breast (female)", "breast (female in situ)",
 
 for (option in female_cancer_options) {
   test_that("incidence female cancer returns non-empty data frame", {
+    skip_on_cran()
     result <- incidence_cancer("wa", "county", option, 
                                "all races (includes hispanic)", "females", 
                                "ages 50+", "all stages", "latest 5 year average")
@@ -48,6 +51,7 @@ childhood_male_cancer_options <- list(
 
 for (option_name in names(childhood_male_cancer_options)) {
   test_that("incidence cancer returns non-empty data frame", {
+    skip_on_cran()
     option <- childhood_male_cancer_options[[option_name]]
     expect_true(is.data.frame(option))
   })
@@ -55,6 +59,7 @@ for (option_name in names(childhood_male_cancer_options)) {
 
 #incidence_cancer must have 14 columns
 test_that("incidence_cancer has correct number of columns", {
+  skip_on_cran()
   df1 <- incidence_cancer("wa", "county", "all cancer sites", "black (non-hispanic)", 
                          "both sexes", "ages 65+", "all stages", "latest 5 year average")
   df2 <- incidence_cancer("usa", "state", "lung & bronchus", "all races (includes hispanic)", "males", 

--- a/tests/testthat/test-mortality-cancer.R
+++ b/tests/testthat/test-mortality-cancer.R
@@ -4,6 +4,7 @@
 #'
 # tests class and typeof output
 test_that("Output data type is correct", {
+  skip_on_cran()
   output <- mortality_cancer("wa", "county", "all cancer sites", "black (non-hispanic)", 
                              "both sexes", "ages 65+", "latest 5 year average")
   
@@ -18,6 +19,7 @@ cancer_options <- c("all cancer sites","bladder", "brain & ons", "colon & rectum
 
 for (option in cancer_options) {
   test_that("mortality cancer returns non-empty data frame", {
+    skip_on_cran()
     result <- mortality_cancer("wa", "county", option, "all races (includes hispanic)", 
                                "both sexes", "all ages", "latest 5 year average")
     expect_true(is.data.frame(result))
@@ -28,6 +30,7 @@ female_cancer_options <- c("breast (female)", "cervix", "ovary", "uterus (corpus
 
 for (option in female_cancer_options) {
   test_that("mortality female cancer returns non-empty data frame", {
+    skip_on_cran()
     result <- mortality_cancer("wa", "county", option, "all races (includes hispanic)", "females", "ages 50+", "latest 5 year average")
     
     expect_true(is.data.frame(result))
@@ -45,6 +48,7 @@ childhood_male_cancer_options <- list(
 
 for (option_name in names(childhood_male_cancer_options)) {
   test_that("mortality cancer returns non-empty data frame", {
+    skip_on_cran()
     option <- childhood_male_cancer_options[[option_name]]
     expect_true(is.data.frame(option))
   })
@@ -52,6 +56,7 @@ for (option_name in names(childhood_male_cancer_options)) {
 
 #mortality_cancer must have 14 columns
 test_that("mortality_cancer has correct number of columns", {
+  skip_on_cran()
   df <- mortality_cancer("wa", "county", "all cancer sites", "black (non-hispanic)", 
                          "both sexes", "ages 65+", "latest 5 year average")
   expected_columns <- 14

--- a/tests/testthat/test-risk-alcohol.R
+++ b/tests/testthat/test-risk-alcohol.R
@@ -4,6 +4,7 @@
 #' 
 #tests class and typeof output
 test_that("Output data type is correct", {
+  skip_on_cran()
   output <- risk_alcohol(paste("binge drinking (4+ drinks on one occasion for women,", 
                                "5+ drinks for one occasion for men), ages 21+"), 
                                "all races (includes hispanic)", "both sexes")
@@ -13,6 +14,7 @@ test_that("Output data type is correct", {
 
 #Ensures that variables are present and working on SCP
 test_that("risk-alcohol returns non-empty data frame", {
+  skip_on_cran()
   alcohol1 <- risk_alcohol(paste("binge drinking (4+ drinks on one occasion for women,", 
                                  "5+ drinks for one occasion for men), ages 21+"), 
                                  "all races (includes hispanic)", "both sexes")
@@ -21,6 +23,7 @@ test_that("risk-alcohol returns non-empty data frame", {
 
 #risk-alcohol must have 5 columns
 test_that("risk-alcohol has correct number of columns", {
+  skip_on_cran()
   df <- risk_alcohol(paste("binge drinking (4+ drinks on one occasion for women,", 
                            "5+ drinks for one occasion for men), ages 21+"), 
                            "all races (includes hispanic)", "both sexes")

--- a/tests/testthat/test-risk-colorectal-screening.R
+++ b/tests/testthat/test-risk-colorectal-screening.R
@@ -4,6 +4,7 @@
 #' 
 #tests class and typeof output
 test_that("Output data type is correct", {
+  skip_on_cran()
   output <- risk_colorectal_screening("ever had fobt, ages 50-75", area="wa")
   
   expect_true(inherits(output, "data.frame"))
@@ -21,6 +22,7 @@ screening_options <- list(
 )
 
 for (option_name in names(screening_options)) {
+  skip_on_cran()
   test_that("risk-colorectal-screening returns non-empty data frame", {
     option <- screening_options[[option_name]]
     expect_true(is.data.frame(option))
@@ -29,6 +31,7 @@ for (option_name in names(screening_options)) {
 
 #risk-colorectal-screening must have 5 columns
 test_that("risk-colorectal-screening has correct number of columns", {
+  skip_on_cran()
   df1 <- risk_colorectal_screening("ever had fobt, ages 50-75", area="wa")
   df2 <- risk_colorectal_screening("home blood stool test in the past year, ages 45-75",
                                    "all races (includes hispanic)","both sexes")
@@ -40,6 +43,7 @@ test_that("risk-colorectal-screening has correct number of columns", {
 
 #test error handling
 test_that("risk-colorectal-screening handles invalid colorectal_screening parameters", {
+  skip_on_cran()
   expect_error(
     risk_colorectal_screening("ever had fobt, ages 50-75", race="all races (includes hispanic)"),
     "for this screening type, area must NOT be NULL and Race and Sex must be NULL"

--- a/tests/testthat/test-risk-diet-exercise.R
+++ b/tests/testthat/test-risk-diet-exercise.R
@@ -4,6 +4,7 @@
 #' 
 #tests class and typeof output
 test_that("Output data type is correct", {
+  skip_on_cran()
   output <- risk_diet_exercise("bmi is healthy, ages 20+", 
                                "all races (includes hispanic)", "both sexes")
   
@@ -18,6 +19,7 @@ diet_exercise_options <- c("bmi is healthy, ages 20+", "bmi is obese, ages 20+",
 
 for (option in diet_exercise_options) {
   test_that("risk_diet_exercise returns non-empty data frame", {
+    skip_on_cran()
     result <- risk_diet_exercise(option, "all races (includes hispanic)", "both sexes")
     expect_true(is.data.frame(result))
   })
@@ -25,6 +27,7 @@ for (option in diet_exercise_options) {
 
 #risk-diet-exercise must have 5 columns
 test_that("risk-diet-exercise has correct number of columns", {
+  skip_on_cran()
   df1 <- risk_diet_exercise("bmi is healthy, ages 20+", 
                            "all races (includes hispanic)", "both sexes")
   df2 <- risk_diet_exercise("bmi is obese, high school survey", 

--- a/tests/testthat/test-risk-smoking.R
+++ b/tests/testthat/test-risk-smoking.R
@@ -4,6 +4,7 @@
 #' 
 #tests class and typeof output
 test_that("Output data type is correct", {
+  skip_on_cran()
   output <- risk_smoking("smoking laws (any)")
   
   expect_true(inherits(output, "data.frame"))
@@ -20,6 +21,7 @@ smoking_group1_options <- c("smoking laws (any)",
 
 for (option in smoking_group1_options) {
   test_that("smoking group1 returns non-empty data frame", {
+    skip_on_cran()
     result <- risk_smoking(option)
     expect_true(is.data.frame(result))
   })
@@ -32,6 +34,7 @@ smoking_group2_options <- c("smokers (stopped for 1 day or longer)",
 
 for (option in smoking_group2_options) {
   test_that("smoking group2 returns non-empty data frame", {
+    skip_on_cran()
     result <- risk_smoking(option, sex="both sexes", datatype="direct estimates")
     expect_true(is.data.frame(result))
   })
@@ -45,6 +48,7 @@ smoking_group3_options <- c("smoking not allowed at work (current smokers)",
 
 for (option in smoking_group3_options) {
   test_that("smoking group3 returns non-empty data frame", {
+    skip_on_cran()
     result <- risk_smoking(option, sex="both sexes", datatype="direct estimates")
     expect_true(is.data.frame(result))
   })
@@ -56,6 +60,7 @@ smoking_group4_options <- c("former smoker; ages 18+",
 
 for (option in smoking_group4_options) {
   test_that("smoking group4 returns non-empty data frame", {
+    skip_on_cran()
     result <- risk_smoking(option, sex="both sexes", 
                            datatype="county level modeled estimates", area="ca")
     expect_true(is.data.frame(result))
@@ -68,6 +73,7 @@ smoking_group5_options <- c("smokers (ever); ages 18+",
 
 for (option in smoking_group5_options) {
   test_that("smoking group5 returns non-empty data frame", {
+    skip_on_cran()
     result <- risk_smoking(option, race="hispanic (any race)", 
                            sex="both sexes", datatype="direct estimates")
     expect_true(is.data.frame(result))
@@ -76,6 +82,7 @@ for (option in smoking_group5_options) {
 
 #group6
 test_that("smoking group6 returns non-empty data frame", {
+  skip_on_cran()
   result <- risk_smoking("smokers (current); ages 18+", race="hispanic (any race)", 
                          sex="both sexes", datatype="direct estimates")
   expect_true(is.data.frame(result))
@@ -84,6 +91,7 @@ test_that("smoking group6 returns non-empty data frame", {
 
 #risk-smoking must have 5 columns
 test_that("risk-smoking has correct number of columns", {
+  skip_on_cran()
   df1 <- risk_smoking("smoking laws (any)")
   df2 <- risk_smoking("smokers (stopped for 1 day or longer)", sex="both sexes", 
                       datatype="county level modeled estimates", area="wa")
@@ -99,6 +107,7 @@ test_that("risk-smoking has correct number of columns", {
 
 #test error handling
 test_that("risk-smoking handles invalid smoking parameters", {
+  skip_on_cran()
   expect_error(
     risk_smoking("smoking laws (any)", sex="both sexes"),
     "For this smoking type, Race, Sex, Datatype, and Area must ALL be NULL"

--- a/tests/testthat/test-risk-vaccines.R
+++ b/tests/testthat/test-risk-vaccines.R
@@ -4,6 +4,7 @@
 #'
 # tests class and typeof output
 test_that("Output data type is correct", {
+  skip_on_cran()
   output <- risk_vaccines("percent with up to date hpv vaccination coverage, ages 13-15",
                          "both sexes")
   
@@ -16,6 +17,7 @@ vaccine_options <- c("percent with up to date hpv vaccination coverage, ages 13-
 
 for (option in vaccine_options) {
   test_that("risk_womens_health returns non-empty data frame", {
+    skip_on_cran()
     result <- risk_vaccines(option, "both sexes")
     expect_true(is.data.frame(result))
   })
@@ -23,6 +25,7 @@ for (option in vaccine_options) {
 
 #risk-vaccines must have 5 columns
 test_that("risk-vaccines has correct number of columns", {
+  skip_on_cran()
   df <- risk_vaccines("percent with up to date hpv vaccination coverage, ages 13-15",
                       "both sexes")
   expected_columns <- 6

--- a/tests/testthat/test-risk-womens-health.R
+++ b/tests/testthat/test-risk-womens-health.R
@@ -4,6 +4,7 @@
 #'
 # tests class and typeof output
 test_that("Output data type is correct", {
+  skip_on_cran()
   output <- risk_women_health("mammogram in past 2 years, ages 50-74", 
                          "all races (includes hispanic)", "direct estimates")
 
@@ -17,6 +18,7 @@ womens_health_options <- c("mammogram in past 2 years, ages 50-74",
 
 for (option in womens_health_options) {
   test_that("risk_womens_health returns non-empty data frame", {
+    skip_on_cran()
     result <- risk_women_health(option, "all races (includes hispanic)", "direct estimates")
     expect_true(is.data.frame(result))
   })
@@ -24,6 +26,7 @@ for (option in womens_health_options) {
 
 #risk-womens health must have 5 columns
 test_that("risk-womens health has correct number of columns", {
+  skip_on_cran()
   df1 <- risk_women_health("mammogram in past 2 years, ages 50-74", 
                       "all races (includes hispanic)", "direct estimates")
   df2 <- risk_women_health("mammogram in past 2 years, ages 50-74", 


### PR DESCRIPTION
@seankross, All tests that query the API has skip_on_cran(). Should we also add this to the test-process-X functions? They are the functions that uses dput_resp that we stored in a separate file.